### PR TITLE
Add CI workflow for Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache CMake deps
+        uses: actions/cache@v3
+        with:
+          path: build/debug/_deps
+          key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
+      - name: Configure
+        run: cmake --preset debug
+
+      - name: Build
+        run: cmake --build --preset debug
+
+      - name: Test
+        run: ctest --preset debug
+
+      - name: Upload sandbox artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-${{ matrix.os }}
+          path: build/debug/samples/sandbox/*


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds and tests on Windows and Linux
- cache CMake FetchContent dependencies and upload sandbox artifact

## Testing
- `ctest --preset debug`


------
https://chatgpt.com/codex/tasks/task_e_689591668180832cb172f2673c1f54f7