### PR TITLE
ci: install dependencies for linux builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xorg-dev python3-jinja2
+
       - name: Cache CMake deps
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary
- install xorg and Jinja2 packages on Ubuntu runners so CMake configuration succeeds

## Testing
- `cmake --preset debug`
- `cmake --build --preset debug`
- `ctest --preset debug`


------
https://chatgpt.com/codex/tasks/task_e_68959570b918832c837048cbb55b207e