### PR TITLE
feat: add basic ECS world

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 
 add_library(engine_core
   engine/src/runtime/runtime.cpp
+  engine/src/ecs/world.cpp
 )
 target_include_directories(engine_core PUBLIC engine/include)
 target_link_libraries(engine_core PUBLIC glm glad glfw)
@@ -84,7 +85,7 @@ add_executable(sandbox samples/sandbox/main.cpp)
 target_link_libraries(sandbox PRIVATE engine_core)
 
 if(USE_CATCH2)
-  add_executable(engine_tests tests/test_dummy.cpp)
+  add_executable(engine_tests tests/test_dummy.cpp tests/test_ecs.cpp)
   target_link_libraries(engine_tests PRIVATE engine_core Catch2::Catch2WithMain)
   include(CTest)
   add_test(NAME engine_tests COMMAND engine_tests)

--- a/engine/include/engine/ecs/entity.hpp
+++ b/engine/include/engine/ecs/entity.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ecs {
+using EntityHandle = std::uint32_t;
+
+struct Entity {
+  EntityHandle id{0};
+  std::uint32_t gen{0};
+  friend constexpr bool operator==(const Entity &, const Entity &) = default;
+};
+} // namespace ecs

--- a/engine/include/engine/ecs/world.hpp
+++ b/engine/include/engine/ecs/world.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include "engine/ecs/entity.hpp"
+#include <cstddef>
+#include <memory>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace ecs {
+class World {
+public:
+  Entity createEntity();
+  void destroyEntity(Entity e);
+
+  template <class T, class... Args> T &add(Entity e, Args &&...args);
+  template <class T> bool has(Entity e) const noexcept;
+  template <class T> T &get(Entity e) noexcept;
+  template <class T> const T &get(Entity e) const noexcept;
+  template <class T> void remove(Entity e) noexcept;
+
+  template <class T0, class... Ts, class Fn> void each(Fn &&fn);
+
+  template <class T> void markOneFrame();
+  void clearOneFrame();
+
+private:
+  using EntityHandle = ecs::EntityHandle;
+  std::vector<std::uint32_t> generations_{};
+  std::vector<EntityHandle> free_{};
+
+  struct IStorage {
+    virtual ~IStorage() = default;
+    virtual void erase(EntityHandle id) = 0;
+    virtual void clear() = 0;
+  };
+
+  template <class T> struct Storage : IStorage {
+    std::vector<T> data{};
+    std::vector<EntityHandle> dense{};
+    std::vector<std::size_t> sparse{};
+
+    void grow(std::size_t n) {
+      if (sparse.size() < n)
+        sparse.resize(n, npos);
+    }
+
+    void erase(EntityHandle id) override {
+      if (id >= sparse.size())
+        return;
+      std::size_t idx = sparse[id];
+      if (idx == npos)
+        return;
+      std::size_t last = data.size() - 1;
+      sparse[id] = npos;
+      if (idx != last) {
+        data[idx] = std::move(data.back());
+        EntityHandle moved = dense.back();
+        dense[idx] = moved;
+        sparse[moved] = idx;
+      }
+      data.pop_back();
+      dense.pop_back();
+    }
+
+    void clear() override {
+      for (EntityHandle id : dense) {
+        if (id < sparse.size())
+          sparse[id] = npos;
+      }
+      data.clear();
+      dense.clear();
+    }
+  };
+
+  template <class T> Storage<T> *storage();
+  template <class T> const Storage<T> *storage() const;
+
+  static constexpr std::size_t npos = static_cast<std::size_t>(-1);
+  std::unordered_map<std::size_t, std::unique_ptr<IStorage>> storages_{};
+  std::unordered_set<std::size_t> one_frame_{};
+};
+
+// --- template implementations ---
+
+template <class T> typename World::Storage<T> *World::storage() {
+  auto key = typeid(T).hash_code();
+  auto it = storages_.find(key);
+  if (it == storages_.end()) {
+    auto ptr = std::make_unique<Storage<T>>();
+    auto *raw = ptr.get();
+    storages_.emplace(key, std::move(ptr));
+    return raw;
+  }
+  return static_cast<Storage<T> *>(it->second.get());
+}
+
+template <class T> const typename World::Storage<T> *World::storage() const {
+  auto key = typeid(T).hash_code();
+  auto it = storages_.find(key);
+  if (it == storages_.end()) {
+    return nullptr;
+  }
+  return static_cast<const Storage<T> *>(it->second.get());
+}
+
+template <class T, class... Args> T &World::add(Entity e, Args &&...args) {
+  auto *s = storage<T>();
+  s->grow(generations_.size());
+  auto id = e.id;
+  std::size_t idx = s->sparse[id];
+  if (idx == npos) {
+    idx = s->data.size();
+    s->data.emplace_back(std::forward<Args>(args)...);
+    s->dense.push_back(id);
+    s->sparse[id] = idx;
+  } else {
+    s->data[idx] = T(std::forward<Args>(args)...);
+  }
+  return s->data[idx];
+}
+
+template <class T> bool World::has(Entity e) const noexcept {
+  auto *s = storage<T>();
+  if (!s)
+    return false;
+  return e.id < s->sparse.size() && s->sparse[e.id] != npos;
+}
+
+template <class T> T &World::get(Entity e) noexcept {
+  auto *s = storage<T>();
+  return s->data[s->sparse[e.id]];
+}
+
+template <class T> const T &World::get(Entity e) const noexcept {
+  auto const *s = storage<T>();
+  return s->data[s->sparse[e.id]];
+}
+
+template <class T> void World::remove(Entity e) noexcept {
+  auto *s = storage<T>();
+  s->erase(e.id);
+}
+
+template <class T0, class... Ts, class Fn> void World::each(Fn &&fn) {
+  auto *primary = storage<T0>();
+  for (std::size_t i = 0; i < primary->dense.size(); ++i) {
+    EntityHandle id = primary->dense[i];
+    Entity ent{id, generations_[id]};
+    if ((has<Ts>(ent) && ...)) {
+      fn(ent, primary->data[i], get<Ts>(ent)...);
+    }
+  }
+}
+
+template <class T> void World::markOneFrame() { one_frame_.insert(typeid(T).hash_code()); }
+
+} // namespace ecs

--- a/engine/src/ecs/world.cpp
+++ b/engine/src/ecs/world.cpp
@@ -1,0 +1,34 @@
+#include "engine/ecs/world.hpp"
+
+namespace ecs {
+Entity World::createEntity() {
+  EntityHandle id{};
+  if (!free_.empty()) {
+    id = free_.back();
+    free_.pop_back();
+  } else {
+    id = static_cast<EntityHandle>(generations_.size());
+    generations_.push_back(0);
+  }
+  return Entity{id, generations_[id]};
+}
+
+void World::destroyEntity(Entity e) {
+  if (e.id >= generations_.size() || generations_[e.id] != e.gen)
+    return;
+  for (auto &[_, storage] : storages_) {
+    storage->erase(e.id);
+  }
+  ++generations_[e.id];
+  free_.push_back(e.id);
+}
+
+void World::clearOneFrame() {
+  for (auto h : one_frame_) {
+    auto it = storages_.find(h);
+    if (it != storages_.end()) {
+      it->second->clear();
+    }
+  }
+}
+} // namespace ecs

--- a/tests/test_ecs.cpp
+++ b/tests/test_ecs.cpp
@@ -1,0 +1,47 @@
+#include "engine/ecs/world.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+struct PositionComponent {
+  int value;
+};
+
+struct VelocityComponent {
+  int value;
+};
+
+struct EventComponent {
+  int value;
+};
+
+TEST_CASE("entity lifecycle") {
+  ecs::World world;
+  auto e = world.createEntity();
+  world.add<PositionComponent>(e, PositionComponent{1});
+  REQUIRE(world.has<PositionComponent>(e));
+  auto &p = world.get<PositionComponent>(e);
+  REQUIRE(p.value == 1);
+  world.destroyEntity(e);
+  REQUIRE_FALSE(world.has<PositionComponent>({e.id, e.gen}));
+}
+
+TEST_CASE("iteration over components") {
+  ecs::World world;
+  auto e1 = world.createEntity();
+  auto e2 = world.createEntity();
+  world.add<PositionComponent>(e1, PositionComponent{1});
+  world.add<PositionComponent>(e2, PositionComponent{2});
+  world.add<VelocityComponent>(e2, VelocityComponent{3});
+  int sum = 0;
+  world.each<PositionComponent>([&](ecs::Entity /*ent*/, PositionComponent &p) { sum += p.value; });
+  REQUIRE(sum == 3);
+}
+
+TEST_CASE("one-frame components are cleared") {
+  ecs::World world;
+  world.markOneFrame<EventComponent>();
+  auto e = world.createEntity();
+  world.add<EventComponent>(e, EventComponent{5});
+  REQUIRE(world.has<EventComponent>(e));
+  world.clearOneFrame();
+  REQUIRE_FALSE(world.has<EventComponent>(e));
+}


### PR DESCRIPTION
## Summary
- implement ECS entity and world with sparse-set storage and one-frame cleanup
- add unit tests for entity lifecycle, iteration, and one-frame components

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_GLFW=ON -DUSE_CATCH2=ON`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6895a17fefc0832ca2f736029ef61a09