### PR TITLE
feat: add const iteration for ECS world

### DIFF
--- a/engine/include/engine/ecs/world.hpp
+++ b/engine/include/engine/ecs/world.hpp
@@ -21,6 +21,7 @@ public:
   template <class T> void remove(Entity e) noexcept;
 
   template <class T0, class... Ts, class Fn> void each(Fn &&fn);
+  template <class T0, class... Ts, class Fn> void each(Fn &&fn) const;
 
   template <class T> void markOneFrame();
   void clearOneFrame();
@@ -145,6 +146,19 @@ template <class T> void World::remove(Entity e) noexcept {
 
 template <class T0, class... Ts, class Fn> void World::each(Fn &&fn) {
   auto *primary = storage<T0>();
+  for (std::size_t i = 0; i < primary->dense.size(); ++i) {
+    EntityHandle id = primary->dense[i];
+    Entity ent{id, generations_[id]};
+    if ((has<Ts>(ent) && ...)) {
+      fn(ent, primary->data[i], get<Ts>(ent)...);
+    }
+  }
+}
+
+template <class T0, class... Ts, class Fn> void World::each(Fn &&fn) const {
+  auto const *primary = storage<T0>();
+  if (!primary)
+    return;
   for (std::size_t i = 0; i < primary->dense.size(); ++i) {
     EntityHandle id = primary->dense[i];
     Entity ent{id, generations_[id]};

--- a/tests/test_ecs.cpp
+++ b/tests/test_ecs.cpp
@@ -45,3 +45,22 @@ TEST_CASE("one-frame components are cleared") {
   world.clearOneFrame();
   REQUIRE_FALSE(world.has<EventComponent>(e));
 }
+
+TEST_CASE("remove component") {
+  ecs::World world;
+  auto e = world.createEntity();
+  world.add<PositionComponent>(e, PositionComponent{1});
+  world.remove<PositionComponent>(e);
+  REQUIRE_FALSE(world.has<PositionComponent>(e));
+}
+
+TEST_CASE("const iteration") {
+  ecs::World world;
+  auto e = world.createEntity();
+  world.add<PositionComponent>(e, PositionComponent{4});
+  const ecs::World &cworld = world;
+  int sum = 0;
+  cworld.each<PositionComponent>(
+      [&](ecs::Entity /*ent*/, const PositionComponent &p) { sum += p.value; });
+  REQUIRE(sum == 4);
+}


### PR DESCRIPTION
## Summary
- support const iteration in ECS world
- test component removal and const iteration

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_GLFW=ON -DUSE_CATCH2=ON`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6895a4b595bc832cb12c8e5ad2ccdcd9