### PR TITLE
feat: add OpenGL vertex array wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,10 +81,11 @@ add_library(engine_core
 target_include_directories(engine_core PUBLIC engine/include)
 target_link_libraries(engine_core PUBLIC glm glad glfw)
 
-add_library(engine_render_gl
-  engine/src/render/gl/shader.cpp
-  engine/src/render/gl/buffer.cpp
-)
+  add_library(engine_render_gl
+    engine/src/render/gl/shader.cpp
+    engine/src/render/gl/buffer.cpp
+    engine/src/render/gl/vertex_array.cpp
+  )
 target_include_directories(engine_render_gl PUBLIC engine/include)
 target_link_libraries(engine_render_gl PUBLIC glad)
 

--- a/engine/include/engine/render/gl/vertex_array.hpp
+++ b/engine/include/engine/render/gl/vertex_array.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <glad/gl.h>
+
+namespace engine::render::gl {
+
+class VertexArray {
+public:
+  VertexArray();
+  ~VertexArray() noexcept;
+  VertexArray(const VertexArray &) = delete;
+  VertexArray &operator=(const VertexArray &) = delete;
+  VertexArray(VertexArray &&other) noexcept;
+  VertexArray &operator=(VertexArray &&other) noexcept;
+
+  void bind() const noexcept;
+  [[nodiscard]] GLuint id() const noexcept { return id_; }
+
+private:
+  GLuint id_{};
+};
+
+} // namespace engine::render::gl

--- a/engine/src/render/gl/vertex_array.cpp
+++ b/engine/src/render/gl/vertex_array.cpp
@@ -1,0 +1,26 @@
+#include "engine/render/gl/vertex_array.hpp"
+
+namespace engine::render::gl {
+
+VertexArray::VertexArray() { glGenVertexArrays(1, &id_); }
+
+VertexArray::~VertexArray() noexcept {
+  if (id_ != 0)
+    glDeleteVertexArrays(1, &id_);
+}
+
+VertexArray::VertexArray(VertexArray &&other) noexcept : id_(other.id_) { other.id_ = 0; }
+
+VertexArray &VertexArray::operator=(VertexArray &&other) noexcept {
+  if (this != &other) {
+    if (id_ != 0)
+      glDeleteVertexArrays(1, &id_);
+    id_ = other.id_;
+    other.id_ = 0;
+  }
+  return *this;
+}
+
+void VertexArray::bind() const noexcept { glBindVertexArray(id_); }
+
+} // namespace engine::render::gl

--- a/samples/sandbox/main.cpp
+++ b/samples/sandbox/main.cpp
@@ -1,4 +1,6 @@
+#include "engine/render/gl/buffer.hpp"
 #include "engine/render/gl/shader.hpp"
+#include "engine/render/gl/vertex_array.hpp"
 #include "engine/runtime/runtime.hpp"
 #include <glad/gl.h>
 
@@ -45,12 +47,11 @@ int main() {
       -0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 0.5f, -0.5f, 0.0f,
       0.0f,  1.0f,  0.0f, 0.0f, 0.5f, 0.0f, 0.0f, 0.0f,  1.0f,
   };
-  GLuint vao = 0, vbo = 0;
-  glGenVertexArrays(1, &vao);
-  glGenBuffers(1, &vbo);
-  glBindVertexArray(vao);
-  glBindBuffer(GL_ARRAY_BUFFER, vbo);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+  engine::render::gl::VertexArray vao;
+  engine::render::gl::Buffer vbo(GL_ARRAY_BUFFER);
+  vao.bind();
+  vbo.bind();
+  vbo.setData(vertices, sizeof(vertices), GL_STATIC_DRAW);
   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void *)0);
   glEnableVertexAttribArray(0);
   glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void *)(3 * sizeof(float)));
@@ -60,12 +61,10 @@ int main() {
     glClearColor(0.1f, 0.1f, 0.2f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT);
     program.use();
-    glBindVertexArray(vao);
+    vao.bind();
     glDrawArrays(GL_TRIANGLES, 0, 3);
     glfwSwapBuffers(app.window());
   }
 
-  glDeleteVertexArrays(1, &vao);
-  glDeleteBuffers(1, &vbo);
   return 0;
 }


### PR DESCRIPTION
## Summary
- add RAII wrapper for OpenGL vertex arrays
- use buffer and vertex array wrappers in sandbox sample
- hook new source file into build

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_GLFW=ON -DUSE_CATCH2=ON`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68ab53de7bf4832cbdb12618c5bb9ee3